### PR TITLE
Add pypi-publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          python -m pip install poetry
+      - name: Build and publish
+        run: |
+          poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry build
+          poetry publish
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## WHY
- This package is currently doing releases manually and would like to automate them using GitHub Actions.

## WHAT
- Add a workflow to publish PyPI when a release is published.
  - From now on, we will need to create a release on GitHub when we version up carling package.

## NOTE
- I have not checked if this workflow works properly, maybe we should test it using TestPyPI or something.