### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - carling/**
       - .github/workflows/ci.yml
+      - poetry.lock
 
 jobs:
   test:


### PR DESCRIPTION
## WHY
Configure [dependabot](https://dependabot.com/) for this repo to keep dependencies up-to-date.