### PR TITLE
Add support for python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 include = ["carling/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<3.11"
 apache-beam = "^2.33.0"
 deepdiff = "^5.6.0"
 


### PR DESCRIPTION
## WHY
We have not tested this libraly with Python 3.10 so far, but PyPI shows 3.10 as supported, which caused confusion.

## WHAT
- Add Python 3.10 tests to CI workflow.  ab04bbe6d90226ba8860501bb95efcb1e9900560
- Specify the supported Python versions more precisely in `pyproject.toml`.  8d834d6d67d536a17e8b5db738223a148dc76014

## NOTICE
Apache Beam Python SDK doesn't supports Python 3.9 and 3.10 now.
- https://issues.apache.org/jira/browse/BEAM-12000