### PR TITLE
Bump version to v0.3.5

### DIFF
--- a/carling/__init__.py
+++ b/carling/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 from .categorical import (
     CreateCategoricalDicts,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carling"
-version = "0.3.4"
+version = "0.3.5"
 description = "Useful transforms for supporting apache beam pipelines."
 authors = [
     "Adam Moore <adam@mcdigital.jp>",

--- a/tests/test_common_transforms.py
+++ b/tests/test_common_transforms.py
@@ -2,4 +2,4 @@ from carling import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.4"
+    assert __version__ == "0.3.5"


### PR DESCRIPTION
## WHAT
Bumping the release to `v0.3.5`.
It includes some dependency updates. (mainly apache-beam to `2.39.0`)