### PR TITLE
Fix CI error caused by tox and poetry updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - carling/**
       - .github/workflows/ci.yml
       - poetry.lock
+      - tox.ini
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install Poetry
+        run: pipx install poetry==1.3.2
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: "poetry"
       - name: Install dependencies
-        run: |
-          python -m pip install poetry tox
+        run: poetry install
       - name: Test with tox
         run: poetry run tox -e py,black,flake8,isort

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 
 [testenv]
 skip_install = true
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install
     poetry run pytest -vv tests


### PR DESCRIPTION
## Why

CI is failing

- `failed with poetry is not allowed, use allowlist_externals to allow it`
  - `whitelist_externals` was deprecated (https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4)
- error from package version difference between `poetry.lock` and CI

## What

- [x] fix `whitelist_externals` to `allowlist_externals`
- [x] fix to install dependency with `poetry install` in CI